### PR TITLE
Initial express setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "body-parser": "^1.20.0",
+        "dotenv": "^16.0.3",
         "express": "^4.18.1",
         "jquery": "^3.6.1",
         "react": "^18.2.0",
@@ -2986,6 +2987,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -7935,6 +7944,11 @@
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "body-parser": "^1.20.0",
+    "dotenv": "^16.0.3",
     "express": "^4.18.1",
     "jquery": "^3.6.1",
     "react": "^18.2.0",

--- a/server/index.js
+++ b/server/index.js
@@ -8,10 +8,6 @@ app.use(express.json());
 app.use(express.urlencoded());
 app.use(express.static(__dirname + '/../client/dist'));
 
-app.get('/', (req, res) => {
-  res.send('Hello World!');
-});
-
 app.listen(port, () => {
   console.log(`App listening on port ${port}`);
 })

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,17 @@
+require("dotenv").config();
+
+const express = require('express');
+const app = express();
+const port = process.env.PORT;
+
+app.use(express.json());
+app.use(express.urlencoded());
+app.use(express.static(__dirname + '/../client/dist'));
+
+app.get('/', (req, res) => {
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  console.log(`App listening on port ${port}`);
+})


### PR DESCRIPTION
**Description**
I created an initial express setup.  This includes two middleware functions and serves up the static files from the client/dist folder.

I've tested it using our `npm run server-dev` script and confirmed that the terminal shows "App listening on port 3000".