### PR TITLE
Initial related products setup

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import RelatedItems from './relatedItems/RelatedItems.jsx';
 
 class App extends React.Component {
   constructor(props) {
@@ -7,7 +8,7 @@ class App extends React.Component {
 
   render() {
     return (<div>
-      I LOAD!
+      <RelatedItems />
     </div>)
   }
 }

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div>
+      I LOAD!
+    </div>)
+  }
+}
+
+export default App;

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class RelatedItems extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div>
+      <h1>Related Items and Comparison</h1>
+    </div>)
+  }
+}
+
+export default RelatedItems;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,6 +1,6 @@
-
 import React from 'react';
 import reactDom from 'react-dom';
+import App from './components/App.jsx';
 
 const Atelier = () => {
   return (

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,4 +1,11 @@
 
+import React from 'react';
+import reactDom from 'react-dom';
 
+const Atelier = () => {
+  return (
+    <App />
+  );
+};
 
-// ReactDOM.render(<App />, document.getElementById('root'));
+reactDom.render(<Atelier />, document.getElementById('root'));


### PR DESCRIPTION
Created the initial rendering of the Related Items and Comparison widget.

This changes includes:

- Setting up the index component to call the higher-level App component
- Setting up the App component to call the RelatedItems widget

Here's a screenshot of the loaded page for RelatedItems:
![image](https://user-images.githubusercontent.com/93614292/193423490-d3b04ebb-dba7-43e1-b3d8-24cbb1affc56.png)
