### PR TITLE
Setup related items components

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -58,3 +58,10 @@
    padding: 16px;
    margin: auto;
  }
+
+ .product-card {
+  background-color: lightgrey;
+  padding: 10px;
+  margin: 5px;
+
+ }

--- a/client/src/components/relatedItems/ComparisonModal.jsx
+++ b/client/src/components/relatedItems/ComparisonModal.jsx
@@ -6,7 +6,7 @@ class ComparisonModal extends React.Component {
   }
 
   render() {
-    return (<div className='related-products'>
+    return (<div className='comparison-modal'>
       <div>Comparison Modal</div>
     </div>)
   }

--- a/client/src/components/relatedItems/ComparisonModal.jsx
+++ b/client/src/components/relatedItems/ComparisonModal.jsx
@@ -7,7 +7,7 @@ class ComparisonModal extends React.Component {
 
   render() {
     return (<div className='related-products'>
-      <h2>Comparison Modal</h2>
+      <div>Comparison Modal</div>
     </div>)
   }
 }

--- a/client/src/components/relatedItems/ComparisonModal.jsx
+++ b/client/src/components/relatedItems/ComparisonModal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class ComparisonModal extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div className='related-products'>
+      <h2>Comparison Modal</h2>
+    </div>)
+  }
+}
+
+export default ComparisonModal;

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class Outfits extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div className='related-products'>
+      <h2>My Outfits</h2>
+    </div>)
+  }
+}
+
+export default Outfits;

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -7,7 +7,7 @@ class Outfits extends React.Component {
   }
 
   render() {
-    return (<div className='related-products'>
+    return (<div className='outfits'>
       <h2>My Outfits</h2>
       <ProductCard />
       <ProductCard />

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ProductCard from './ProductCard.jsx';
 
 class Outfits extends React.Component {
   constructor(props) {
@@ -8,6 +9,8 @@ class Outfits extends React.Component {
   render() {
     return (<div className='related-products'>
       <h2>My Outfits</h2>
+      <ProductCard />
+      <ProductCard />
     </div>)
   }
 }

--- a/client/src/components/relatedItems/ProductCard.jsx
+++ b/client/src/components/relatedItems/ProductCard.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class ProductCard extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div className='product-card'>
+      <h3>Product Card</h3>
+    </div>)
+  }
+}
+
+export default ProductCard;

--- a/client/src/components/relatedItems/ProductCard.jsx
+++ b/client/src/components/relatedItems/ProductCard.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import ComparisonModal from './ComparisonModal.jsx';
+
 
 class ProductCard extends React.Component {
   constructor(props) {

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import RelatedProducts from './RelatedProducts.jsx';
+import Outfits from './Outfits.jsx';
+
 
 class RelatedItems extends React.Component {
   constructor(props) {
@@ -8,6 +11,8 @@ class RelatedItems extends React.Component {
   render() {
     return (<div>
       <h1>Related Items and Comparison</h1>
+      <RelatedProducts />
+      <Outfits />
     </div>)
   }
 }

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class RelatedProducts extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<div className='related-products'>
+      <h2>Related Products</h2>
+    </div>)
+  }
+}
+
+export default RelatedProducts;

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ProductCard from './ProductCard.jsx';
 
 class RelatedProducts extends React.Component {
   constructor(props) {
@@ -8,6 +9,8 @@ class RelatedProducts extends React.Component {
   render() {
     return (<div className='related-products'>
       <h2>Related Products</h2>
+      <ProductCard />
+      <ProductCard />
     </div>)
   }
 }


### PR DESCRIPTION
Decided on four separate components to make up the Related Items widget, which are as follows:

- Product Card - this will be where information is displayed and most user interaction occurs
- Related Items - will display a horizontal grid of product cards
- Outfits - will display a horizontal grid of product cards
- Comparison Modal - will appear when a product card from the related items component's action button is clicked.

The page has rendered with the correct connections between components.  The gray is a place-holder to better see the product card.  This will not be the final implementation UI.  Screenshot of rendered page below:
![image](https://user-images.githubusercontent.com/93614292/193426029-41125ae2-8b03-402d-b0bf-80b925662bbc.png)
