### PR TITLE
Related products click

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -5,7 +5,7 @@ import RelatedItems from './relatedItems/RelatedItems.jsx';
 import RatingsReviews from './ratings&reviews/RatingsReviews.jsx';
 
 const App = () => {
-  const [product_id, setId] = useState(71697);
+  const [product_id, setId] = useState(71698);
   const [reviews, setReviews] = useState();
   const [metaData, setMetaData] = useState();
   const [ratings, setRatings] = useState({1:0, 2:0, 3:0, 4:0, 5:0});
@@ -32,7 +32,7 @@ const App = () => {
 
     return (<div>
       <Overview />
-      <RelatedItems />
+      <RelatedItems productId={product_id}/>
       <RatingsReviews product_id={product_id} reviews={reviews} metaData={metaData} ratings={ratings}/>
     </div>)
 

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -5,7 +5,7 @@ import RelatedItems from './relatedItems/RelatedItems.jsx';
 import RatingsReviews from './ratings&reviews/RatingsReviews.jsx';
 
 const App = () => {
-  const [product_id, setId] = useState(71698);
+  const [product_id, setId] = useState(71697);
   const [reviews, setReviews] = useState();
   const [metaData, setMetaData] = useState();
   const [ratings, setRatings] = useState({1:0, 2:0, 3:0, 4:0, 5:0});
@@ -22,7 +22,12 @@ const App = () => {
       .catch(err => {console.log(err)});
   }
 
+  const setNewProductId = (newProductId) => {
+    setId(newProductId);
+  }
+
   useEffect(() => {
+    console.log('HERE');
     getData();
   }, [])
 
@@ -32,8 +37,8 @@ const App = () => {
 
     return (<div>
       <Overview />
-      <RelatedItems productId={product_id}/>
-      <RatingsReviews product_id={product_id} reviews={reviews} metaData={metaData} ratings={ratings}/>
+      <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId}/>
+      <RatingsReviews key={`rr_${product_id}`} product_id={product_id} reviews={reviews} metaData={metaData} ratings={ratings}/>
     </div>)
 
 }

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -38,7 +38,7 @@ const App = () => {
     return (<div>
       <Overview />
       <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId}/>
-      <RatingsReviews key={`rr_${product_id}`} product_id={product_id} reviews={reviews} metaData={metaData} ratings={ratings}/>
+      <RatingsReviews product_id={product_id} reviews={reviews} metaData={metaData} ratings={ratings}/>
     </div>)
 
 }

--- a/client/src/components/relatedItems/ProductCard.jsx
+++ b/client/src/components/relatedItems/ProductCard.jsx
@@ -17,6 +17,12 @@ class ProductCard extends React.Component {
       salesPrice: 0,
       imgUrl: ''
     }
+
+    this.updateProduct = this.updateProduct.bind(this);
+  }
+
+  updateProduct() {
+    this.props.setNewProductId(this.props.productId);
   }
 
   componentDidMount() {
@@ -77,7 +83,7 @@ class ProductCard extends React.Component {
   }
 
   render() {
-    return (<div id='product-card'>
+    return (<div id='product-card' onClick={() => {this.updateProduct()}}>
       <div id='ri-image-block'>
         <img id='ri-image' src={this.state.imgUrl} alt='product image'></img>
       </div>

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -12,7 +12,7 @@ class RelatedItems extends React.Component {
   render() {
     return (<div id='related-items-and-comparisons'>
       <h2>Related Items and Comparison</h2>
-      <RelatedProducts productId={this.props.productId}/>
+      <RelatedProducts productId={this.props.productId} setNewProductId={this.props.setNewProductId}/>
       <Outfits />
     </div>)
   }

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -12,7 +12,7 @@ class RelatedItems extends React.Component {
   render() {
     return (<div id='related-items-and-comparisons'>
       <h2>Related Items and Comparison</h2>
-      <RelatedProducts />
+      <RelatedProducts productId={this.props.productId}/>
       <Outfits />
     </div>)
   }

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -28,7 +28,7 @@ class RelatedProducts extends React.Component {
   }
 
   componentDidMount() {
-    this.getRelatedProducts(this.state.productId);
+    this.getRelatedProducts(this.props.productId);
   }
 
   render() {

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -35,7 +35,7 @@ class RelatedProducts extends React.Component {
     return (<div id='related-products'>
       <h3>Related Products</h3>
       {this.state.relatedProducts.map((productId) =>
-        <ProductCard key={productId.toString()} productId={productId}/>)}
+        <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId}/>)}
     </div>)
   }
 }


### PR DESCRIPTION
There are two main things handled in this PR:

- product Id information is passed down from the higher level App component to all relevant Related Items components
- Clicking on a product card from the related items widget will update the product_id state in App.

This PR handles the re-rendering of the related item components upon state change, but it DOES not handle re-rendering in any of the other widgets.