### PR TITLE
Add Error Boundaries

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import Overview from './overview/Overview.jsx';
 import RelatedItems from './relatedItems/RelatedItems.jsx';
 import RatingsReviews from './ratings&reviews/RatingsReviews.jsx';
+import ErrorBoundary from './ErrorBoundary.jsx';
 import { reviewsCall, reviewsFilter } from './helpers/reviewsHelpers.js';
 
 const App = () => {
@@ -63,7 +64,9 @@ const App = () => {
 
     return (<div>
       <Overview />
-      <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId}/>
+      <ErrorBoundary>
+        <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId}/>
+      </ErrorBoundary>
       <RatingsReviews
       product_id={product_id}
       reviews={reviews}

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -63,20 +63,24 @@ const App = () => {
   if (pageLoading) { return 'Page is Loading'}
 
     return (<div>
-      <Overview />
+      <ErrorBoundary>
+        <Overview />
+      </ErrorBoundary>
       <ErrorBoundary>
         <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId}/>
       </ErrorBoundary>
-      <RatingsReviews
-      product_id={product_id}
-      reviews={reviews}
-      setReviews={setReviews}
-      metaData={metaData}
-      ratings={ratings}
-      filter={filter}
-      setFilter={setFilter}
-      sorted={sorted}
-      setSorted={setSorted} />
+      <ErrorBoundary>
+        <RatingsReviews
+        product_id={product_id}
+        reviews={reviews}
+        setReviews={setReviews}
+        metaData={metaData}
+        ratings={ratings}
+        filter={filter}
+        setFilter={setFilter}
+        sorted={sorted}
+        setSorted={setSorted} />
+      </ErrorBoundary>
     </div>)
 
 }

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // You can also log the error to an error reporting service
+    console.log(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import reactDom from 'react-dom';
 import App from './components/App.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
+
 
 const Atelier = () => {
   return (
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
A simplistic error boundary component was implemented in four locations.  One for the overall page, and one around each of the widgets.  The image below shows what this looks like when the Related Items widget throws an error.

![image](https://user-images.githubusercontent.com/93614292/196338363-8e0f871d-c102-4a3f-bb05-d30880918aec.png)
