### PR TITLE
Create carousel

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -67,8 +67,6 @@
   background-color: rgb(92, 39, 39);
   margin: 10px;
   padding: 10px;
-  overflow-x: scroll;
-  white-space: nowrap;
  }
 
  #related-items-and-comparisons{
@@ -82,6 +80,7 @@
   position: absolute;
   top: 10px;
   right: 10px;
+  cursor: pointer;
  }
 
  .ri-product-info {
@@ -160,8 +159,7 @@ td:nth-child(2) {
 
 #carousel {
   width: 90%;
-  height: 300px;
-  background-color: #fff;
+  height: 305px;
   position: relative;
   display: flex;
   align-items: center;
@@ -173,13 +171,21 @@ td:nth-child(2) {
   background-color: rgb(92, 39, 39);
   white-space: nowrap;
   overflow-x: scroll;
+  scrollbar-width: none;
+}
+
+#carousel-content::-webkit-scrollbar {
+  display: none;
 }
 
 .carousel-button{
   background-color: white;
   border-radius: 100%;
   position: absolute;
-  opacity: 0.2;
+  opacity: 0.5;
+  box-shadow: 2px 2px 2px 2px rgb(0 0 0 / 12%);
+  cursor: pointer;
+  z-index: 1;
 }
 
 .carousel-button.left {

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -103,6 +103,7 @@
   width: 100%;
   height: 100%;
   object-fit: contain;
+  cursor: pointer;
  }
 
  .ri-category, .ri-original-price {
@@ -172,6 +173,7 @@ td:nth-child(2) {
   white-space: nowrap;
   overflow-x: scroll;
   scrollbar-width: none;
+  scroll-behavior: smooth;
 }
 
 #carousel-content::-webkit-scrollbar {

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -152,7 +152,7 @@ td:nth-child(2) {
   font-size: 10px;
 }
 
-#carousel {
+.carousel {
   width: 100%;
   height: 305px;
   position: relative;
@@ -160,7 +160,7 @@ td:nth-child(2) {
   align-items: center;
 }
 
-#carousel-content {
+#carousel-outfit, #carousel-related-products {
   width: 100%;
   height: 100%;
   background-color:  #2196F3;
@@ -170,7 +170,7 @@ td:nth-child(2) {
   scroll-behavior: smooth;
 }
 
-#carousel-content::-webkit-scrollbar {
+#carousel-outfit::-webkit-scrollbar, #carousel-related-products::-webkit-scrollbar{
   display: none;
 }
 

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -58,21 +58,12 @@
  /* RELATED ITEMS AND COMPARISON FORMATTING */
 
  #related-items-and-comparisons{
-  background-color: lightgrey;
-  padding: 10px;
-  margin: 5px;
- }
-
- #related-products, #outfits {
   background-color:  #2196F3;
-  margin: 10px;
-  padding: 10px;
- }
-
- #related-items-and-comparisons{
   position: relative;
-  padding: 10px;
-  margin: 5px;
+  margin-top: 10px;
+  padding-left: 10px;
+  padding-bottom: 10px;
+  padding-top: 10px;
  }
 
  .ri-action-button {
@@ -80,6 +71,13 @@
   top: 10px;
   right: 10px;
   cursor: pointer;
+  border-radius: 100%;
+  opacity: 0.75;
+  box-shadow: 1px 1px 1px 1px rgb(0 0 0 / 50%);
+ }
+
+ .ri-action-button:hover {
+  opacity: 1;
  }
 
  .ri-product-info {

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -87,22 +87,16 @@
   position: absolute;
   width: 90%;
   height: 25%;
-  background-color: beige;
   bottom: 10px;
   left: 5%;
+  border-radius: 5px;
  }
 
  .ri-image-block {
-  text-align: center;
-  width: 90%;
-  height: 70%;
-  left: 5%;
- }
-
- .ri-image {
   width: 100%;
-  height: 100%;
-  object-fit: contain;
+  height: 200px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
   cursor: pointer;
  }
 
@@ -127,6 +121,7 @@
   height: 250px;
   overflow: auto;
   box-shadow: 10px 10px rgba(0, 0, 0, 0.25);
+  z-index: 2;
  }
 
  .ri-comparison-table {
@@ -202,21 +197,14 @@ td:nth-child(2) {
   opacity: 1;
 }
 
-/*.product-card{
-
-  position: relative;
-  text-align: center;
-}*/
-
 .product-card {
   display: inline-block;
   width: 240px;
   height: 300px;
-  background-color: lightgrey;
+  background-color: white;
   border-radius: 10px;
   margin-left: 5px;
   margin-right: 5px;
-  /*SNH Add*/
   text-align: center;
   position: relative;
 }

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -64,14 +64,13 @@
  }
 
  #related-products, #outfits {
-  background-color: rgb(92, 39, 39);
+  background-color:  #2196F3;
   margin: 10px;
   padding: 10px;
  }
 
  #related-items-and-comparisons{
   position: relative;
-  background-color: lightgrey;
   padding: 10px;
   margin: 5px;
  }
@@ -154,7 +153,7 @@ td:nth-child(2) {
 }
 
 #carousel {
-  width: 90%;
+  width: 100%;
   height: 305px;
   position: relative;
   display: flex;
@@ -164,7 +163,7 @@ td:nth-child(2) {
 #carousel-content {
   width: 100%;
   height: 100%;
-  background-color: rgb(92, 39, 39);
+  background-color:  #2196F3;
   white-space: nowrap;
   overflow-x: scroll;
   scrollbar-width: none;
@@ -207,6 +206,7 @@ td:nth-child(2) {
   margin-right: 5px;
   text-align: center;
   position: relative;
+  box-shadow: 3px 3px 3px 3px rgb(0 0 0 / 30%);
 }
 
 /* OVERVIEW CSS */

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -78,16 +78,6 @@
   margin: 5px;
  }
 
- .product-card{
-  display: inline-block;
-  background-color: lightgrey;
-  width: 240px;
-  height: 300px;
-  position: relative;
-  text-align: center;
-  margin: 10px;
- }
-
  .ri-action-button {
   position: absolute;
   top: 10px;
@@ -180,21 +170,47 @@ td:nth-child(2) {
 #carousel-content {
   width: 100%;
   height: 100%;
-  background-color: black;
+  background-color: rgb(92, 39, 39);
+  white-space: nowrap;
+  overflow-x: scroll;
 }
 
 .carousel-button{
-  background-color: green;
+  background-color: white;
   border-radius: 100%;
   position: absolute;
+  opacity: 0.2;
 }
 
-.left {
+.carousel-button.left {
   left: 0;
 }
 
-.right {
+.carousel-button.right {
   right: 0;
+}
+
+.carousel-button.left:hover, .carousel-button.right:hover {
+  opacity: 1;
+}
+
+/*.product-card{
+
+  position: relative;
+  text-align: center;
+}*/
+
+.product-card {
+  display: inline-block;
+  width: 240px;
+  height: 300px;
+  background-color: lightgrey;
+  border-radius: 10px;
+  margin-left: 5px;
+  margin-right: 5px;
+  /*SNH Add*/
+  text-align: center;
+  position: relative;
 }
 
 /* OVERVIEW CSS */

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -64,13 +64,15 @@
  }
 
  #related-products, #outfits {
-  background-color: darkgray;
+  background-color: rgb(92, 39, 39);
   margin: 10px;
   padding: 10px;
+  overflow-x: scroll;
+  white-space: nowrap;
  }
 
  #related-items-and-comparisons{
-  display: inline-block;
+  position: relative;
   background-color: lightgrey;
   padding: 10px;
   margin: 5px;

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -160,14 +160,18 @@
 td:nth-child(1), td:nth-child(3) {
   width: 150px;
   font-size: 10px;
-
 }
 
 td:nth-child(2) {
   width: 150px;
   font-weight: bold;
   font-size: 10px;
+}
 
+#carousel {
+  width: 90%;
+  height: 300px;
+  background-color: #fff;
 }
 
 /* OVERVIEW CSS */

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -172,6 +172,29 @@ td:nth-child(2) {
   width: 90%;
   height: 300px;
   background-color: #fff;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+#carousel-content {
+  width: 100%;
+  height: 100%;
+  background-color: black;
+}
+
+.carousel-button{
+  background-color: green;
+  border-radius: 100%;
+  position: absolute;
+}
+
+.left {
+  left: 0;
+}
+
+.right {
+  right: 0;
 }
 
 /* OVERVIEW CSS */

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -72,7 +72,7 @@ const App = () => {
 
     return (<div>
       <ErrorBoundary>
-        {/*<Overview productId={product_id} clickTracking={clickTracking} />*/}
+        <Overview productId={product_id} clickTracking={clickTracking} />
       </ErrorBoundary>
       <ErrorBoundary>
         <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId} clickTracking={clickTracking} />

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -72,7 +72,7 @@ const App = () => {
 
     return (<div>
       <ErrorBoundary>
-        <Overview productId={product_id} clickTracking={clickTracking} />
+        {/*<Overview productId={product_id} clickTracking={clickTracking} />*/}
       </ErrorBoundary>
       <ErrorBoundary>
         <RelatedItems key={`ri_${product_id}`} productId={product_id} setNewProductId={setNewProductId} clickTracking={clickTracking} />

--- a/client/src/components/relatedItems/Carousel.jsx
+++ b/client/src/components/relatedItems/Carousel.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+
+class Carousel extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    <h3>CAROUSEL!</h3>
+}
+
+export default Carousel;

--- a/client/src/components/relatedItems/Carousel.jsx
+++ b/client/src/components/relatedItems/Carousel.jsx
@@ -12,7 +12,7 @@ class Carousel extends React.Component {
   }
 
   slideLeft() {
-    var scroller = document.getElementById('carousel-content');
+    var scroller = document.getElementById(this.props.sliderComp);
     console.log(scroller.scrollLeft);
 
     scroller.scrollLeft = scroller.scrollLeft - 260;
@@ -21,7 +21,7 @@ class Carousel extends React.Component {
   }
 
   slideRight() {
-    var scroller = document.getElementById('carousel-content');
+    var scroller = document.getElementById(this.props.sliderComp);
     scroller.scrollLeft = scroller.scrollLeft + 260;
     console.log(scroller.scrollLeft);
   }
@@ -29,9 +29,9 @@ class Carousel extends React.Component {
   render() {
 
     return (
-      <div id='carousel'>
+      <div className='carousel'>
         <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
-        <div id='carousel-content'>
+        <div id={this.props.sliderComp}>
           {this.props.products.map((productId) =>
             <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={this.props.actionButtonIcon} actionClick={this.props.actionClick}/>)}
         </div>

--- a/client/src/components/relatedItems/Carousel.jsx
+++ b/client/src/components/relatedItems/Carousel.jsx
@@ -1,13 +1,45 @@
 import React from 'react';
-
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import ProductCard from './ProductCard.jsx';
 
 class Carousel extends React.Component {
   constructor(props) {
     super(props);
+
+    this.slideLeft = this.slideLeft.bind(this);
+    this.slideRight = this.slideRight.bind(this);
+  }
+
+  slideLeft() {
+    var scroller = document.getElementById('carousel-content');
+    console.log(scroller.scrollLeft);
+
+    scroller.scrollLeft = scroller.scrollLeft - 260;
+    console.log(scroller.scrollLeft);
+
+  }
+
+  slideRight() {
+    var scroller = document.getElementById('carousel-content');
+    scroller.scrollLeft = scroller.scrollLeft + 260;
+    console.log(scroller.scrollLeft);
   }
 
   render() {
-    <h3>CAROUSEL!</h3>
+
+    return (
+      <div id='carousel'>
+        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
+        <div id='carousel-content'>
+          {this.props.products.map((productId) =>
+            <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={this.props.actionButtonIcon} actionClick={this.props.actionClick}/>)}
+        </div>
+        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right' onClick={this.slideRight}/>
+      </div>
+    )
+  }
+
 }
 
 export default Carousel;

--- a/client/src/components/relatedItems/Carousel.jsx
+++ b/client/src/components/relatedItems/Carousel.jsx
@@ -7,35 +7,94 @@ class Carousel extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      showLeftButton: false,
+      showRightButton: false
+    }
+
     this.slideLeft = this.slideLeft.bind(this);
     this.slideRight = this.slideRight.bind(this);
+    this.checkSliders = this.checkSliders.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
   }
 
   slideLeft() {
     var scroller = document.getElementById(this.props.sliderComp);
-    console.log(scroller.scrollLeft);
+    var currentLocation = scroller.scrollLeft;
+    scroller.scrollLeft -= 250;
 
-    scroller.scrollLeft = scroller.scrollLeft - 260;
-    console.log(scroller.scrollLeft);
-
+    this.checkSliders(currentLocation - 250);
   }
 
   slideRight() {
     var scroller = document.getElementById(this.props.sliderComp);
-    scroller.scrollLeft = scroller.scrollLeft + 260;
-    console.log(scroller.scrollLeft);
+    var currentLocation = scroller.scrollLeft;
+    scroller.scrollLeft += 250;
+
+    this.checkSliders(currentLocation + 250);
+  }
+
+  checkSliders(location) {
+    var scroller = document.getElementById(this.props.sliderComp);
+    var productPixelLength = this.props.products.length * 250;
+
+    console.log(this.props.sliderComp);
+    console.log(window.innerWidth);
+    console.log(productPixelLength - location);
+
+    if (this.state.showLeftButton && location <= 0) {
+      this.setState({showLeftButton: false});
+    } else if (!this.state.showLeftButton && location > 0){
+      this.setState({showLeftButton: true});
+    }
+
+    if (this.state.showRightButton && productPixelLength - location < window.innerWidth) {
+      this.setState({showRightButton: false});
+    } else if (!this.state.showRightButton && productPixelLength - location >= window.innerWidth) {
+      this.setState({showRightButton: true});
+    }
+  }
+
+  handleWindowResize() {
+    var scroller = document.getElementById(this.props.sliderComp);
+
+    this.checkSliders(scroller.scrollLeft);
+  }
+
+  componentDidMount() {
+    //window.addEventListener('resize', this.handleWindowResize);
+    this.checkSliders(0);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.products !== prevProps.products) {
+      var scroller = document.getElementById(this.props.sliderComp);
+
+      this.checkSliders(scroller.scrollLeft);
+    }
   }
 
   render() {
+    var leftButton = null;
+    var rightButton = null;
+
+    if (this.state.showLeftButton) {
+      leftButton = <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
+    }
+
+    if (this.state.showRightButton) {
+      rightButton = <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right' onClick={this.slideRight}/>
+
+    }
 
     return (
       <div className='carousel'>
-        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
+        {leftButton}
         <div id={this.props.sliderComp}>
           {this.props.products.map((productId) =>
             <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={this.props.actionButtonIcon} actionClick={this.props.actionClick}/>)}
         </div>
-        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right' onClick={this.slideRight}/>
+        {rightButton}
       </div>
     )
   }

--- a/client/src/components/relatedItems/Carousel.jsx
+++ b/client/src/components/relatedItems/Carousel.jsx
@@ -38,10 +38,6 @@ class Carousel extends React.Component {
     var scroller = document.getElementById(this.props.sliderComp);
     var productPixelLength = this.props.products.length * 250;
 
-    console.log(this.props.sliderComp);
-    console.log(window.innerWidth);
-    console.log(productPixelLength - location);
-
     if (this.state.showLeftButton && location <= 0) {
       this.setState({showLeftButton: false});
     } else if (!this.state.showLeftButton && location > 0){
@@ -62,7 +58,7 @@ class Carousel extends React.Component {
   }
 
   componentDidMount() {
-    //window.addEventListener('resize', this.handleWindowResize);
+    window.addEventListener('resize', this.handleWindowResize);
     this.checkSliders(0);
   }
 

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -8,7 +8,7 @@ class Outfits extends React.Component {
     super(props);
     this.state = {
       productId: 71697,
-      outfits: [71697, 71698, 71699, 71698, 71699]
+      outfits: [71697, 71698, 71699]
     }
 
     this.handleActionButton = this.handleActionButton.bind(this);

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -8,7 +8,7 @@ class Outfits extends React.Component {
     super(props);
     this.state = {
       productId: 71697,
-      outfits: [71697, 71698, 71699]
+      outfits: [71697, 71698, 71699, 71704, 71703]
     }
 
     this.handleActionButton = this.handleActionButton.bind(this);

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -28,7 +28,7 @@ class Outfits extends React.Component {
 
   render() {
     return (<div id='outfits'>
-      <h3>Outfits</h3>
+      <h3>YOUR OUTFIT</h3>
       <Carousel products={this.state.outfits} setNewProductId={this.props.setNewProductId} actionButtonIcon={faX} actionClick={this.handleActionButton} sliderComp='carousel-outfit'/>
     </div>)
   }

--- a/client/src/components/relatedItems/Outfits.jsx
+++ b/client/src/components/relatedItems/Outfits.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProductCard from './ProductCard.jsx';
+import Carousel from './Carousel.jsx';
 import { faX } from '@fortawesome/free-solid-svg-icons'
 
 
@@ -8,7 +8,7 @@ class Outfits extends React.Component {
     super(props);
     this.state = {
       productId: 71697,
-      outfits: [71697, 71698, 71699]
+      outfits: [71697, 71698, 71699, 71698, 71699]
     }
 
     this.handleActionButton = this.handleActionButton.bind(this);
@@ -29,8 +29,7 @@ class Outfits extends React.Component {
   render() {
     return (<div id='outfits'>
       <h3>Outfits</h3>
-      {this.state.outfits.map((productId) =>
-        <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faX} actionClick={this.handleActionButton}/>)}
+      <Carousel products={this.state.outfits} setNewProductId={this.props.setNewProductId} actionButtonIcon={faX} actionClick={this.handleActionButton} sliderComp='carousel-outfit'/>
     </div>)
   }
 }

--- a/client/src/components/relatedItems/ProductCard.jsx
+++ b/client/src/components/relatedItems/ProductCard.jsx
@@ -115,12 +115,11 @@ class ProductCard extends React.Component {
 
   render() {
     return (<div className='product-card' onClick={() => {this.updateProduct()}}>
-      {this.props.productId}
       <button className='ri-action-button' onClick={(e) => {this.takeAction(e)}}>
         <FontAwesomeIcon icon={this.props.actionButtonIcon} />
       </button>
-      <div className='ri-image-block'>
-        <img className='ri-image' src={this.state.imgUrl} alt='product image'></img>
+      <div className='ri-image-block' style={{backgroundImage:`url(${this.state.imgUrl})`, backgroundSize:'cover'}}>
+
       </div>
       <div className='ri-product-info'>
         <div className='ri-category'>{this.state.productCategory}</div>

--- a/client/src/components/relatedItems/ProductCard.jsx
+++ b/client/src/components/relatedItems/ProductCard.jsx
@@ -18,7 +18,7 @@ class ProductCard extends React.Component {
       starRating: 0,
       isOnSale: false,
       salesPrice: 0,
-      imgUrl: ''
+      imgUrl: '../images/fullstar.jpeg'
     }
 
     this.updateProduct = this.updateProduct.bind(this);
@@ -61,26 +61,41 @@ class ProductCard extends React.Component {
       })
     })
     .then(result => {
+      var defaultIndex = 0;
       var haveFoundDefault = false;
       var styles = result.data.results;
 
-      for (var style of styles) {
-        if (style['default?']) {
-          originalPrice = style.original_price;
-
-          imgUrl = style.photos[0].url;
-          if (imgUrl === null) {
-            imgUrl = '../images/fullstar.jpeg';
-          }
-
-          if (style.sale_price !== null) {
-            isOnSale = true;
-            salesPrice = style.sale_price;
-            break;
-          }
+      // Determine if there's a default style
+      while (!haveFoundDefault && defaultIndex < styles.length) {
+        if (styles[defaultIndex]['default?']) {
+          haveFoundDefault = true;
+        } else {
+          defaultIndex++;
         }
       }
 
+      // If no default, choose first style
+      if (!haveFoundDefault) {
+        defaultIndex = 0;
+      }
+
+      // Save values of default style
+      var style = styles[defaultIndex];
+
+      originalPrice = style.original_price;
+
+      imgUrl = style.photos[0].url;
+
+      if (imgUrl === null) {
+        imgUrl = this.state.imgUrl;
+      }
+
+      if (style.sale_price !== null) {
+        isOnSale = true;
+        salesPrice = style.sale_price;
+      }
+
+      //Update state from default style
       this.setState({
         productCategory,
         productName,
@@ -100,6 +115,7 @@ class ProductCard extends React.Component {
 
   render() {
     return (<div className='product-card' onClick={() => {this.updateProduct()}}>
+      {this.props.productId}
       <button className='ri-action-button' onClick={(e) => {this.takeAction(e)}}>
         <FontAwesomeIcon icon={this.props.actionButtonIcon} />
       </button>

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -11,7 +11,6 @@ class RelatedItems extends React.Component {
 
   render() {
     return (<div id='related-items-and-comparisons' onClick={e => this.props.clickTracking(e, 'Related Items')}>
-      <h2>Related Items and Comparison</h2>
       <RelatedProducts productId={this.props.productId} setNewProductId={this.props.setNewProductId}/>
       <Outfits setNewProductId={this.props.setNewProductId}/>
     </div>)

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -53,9 +53,8 @@ class RelatedProducts extends React.Component {
     return (
     <div id='related-products'>
       <h3>Related Products</h3>
-      <Carousel products={this.state.relatedProducts} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>
+      <Carousel products={this.state.relatedProducts} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton} sliderComp='carousel-related-products'/>
       {modal}
-
     </div>)
   }
 }

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ProductCard from './ProductCard.jsx';
 import ComparisonModal from './ComparisonModal.jsx';
-import { faStar } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 const axios = require('axios');
 
 class RelatedProducts extends React.Component {
@@ -50,9 +51,9 @@ class RelatedProducts extends React.Component {
     <div id='related-products'>
       <h3>Related Products</h3>
       <div id='carousel'>
-        <div className='carousel-button left'></div>
+        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left'/>
         <div id='carousel-content'></div>
-        <div className='carousel-button right'></div>
+        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right'/>
       </div>
       {this.state.relatedProducts.map((productId) =>
         <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProductCard from './ProductCard.jsx';
+import Carousel from './Carousel.jsx';
 import ComparisonModal from './ComparisonModal.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
@@ -16,9 +16,6 @@ class RelatedProducts extends React.Component {
 
     this.getRelatedProducts = this.getRelatedProducts.bind(this);
     this.handleActionButton = this.handleActionButton.bind(this);
-    this.slideLeft = this.slideLeft.bind(this);
-    this.slideRight = this.slideRight.bind(this);
-
 
   }
 
@@ -41,17 +38,7 @@ class RelatedProducts extends React.Component {
     this.setState({showModal: newState, comparisonProductId: productId});
   }
 
-  slideLeft() {
-    var scroller = document.getElementById('carousel-content');
-    scroller.scrollLeft = scroller.scrollLeft - 260;
-    console.log(scroller.scrollLeft);
-  }
 
-  slideRight() {
-    var scroller = document.getElementById('carousel-content');
-    scroller.scrollLeft = scroller.scrollLeft + 260;
-    console.log(scroller.scrollLeft);
-  }
 
   componentDidMount() {
     this.getRelatedProducts(this.props.productId);
@@ -66,14 +53,7 @@ class RelatedProducts extends React.Component {
     return (
     <div id='related-products'>
       <h3>Related Products</h3>
-      <div id='carousel'>
-        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
-        <div id='carousel-content'>
-          {this.state.relatedProducts.map((productId) =>
-            <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}
-        </div>
-        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right' onClick={this.slideRight}/>
-      </div>
+      <Carousel products={this.state.relatedProducts} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>
       {modal}
 
     </div>)

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -49,9 +49,15 @@ class RelatedProducts extends React.Component {
     return (
     <div id='related-products'>
       <h3>Related Products</h3>
+      <div id='carousel'>
+        <div className='carousel-button left'></div>
+        <div id='carousel-content'></div>
+        <div className='carousel-button right'></div>
+      </div>
       {this.state.relatedProducts.map((productId) =>
         <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}
       {modal}
+
     </div>)
   }
 }

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -38,8 +38,6 @@ class RelatedProducts extends React.Component {
     this.setState({showModal: newState, comparisonProductId: productId});
   }
 
-
-
   componentDidMount() {
     this.getRelatedProducts(this.props.productId);
   }

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -52,11 +52,12 @@ class RelatedProducts extends React.Component {
       <h3>Related Products</h3>
       <div id='carousel'>
         <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left'/>
-        <div id='carousel-content'></div>
+        <div id='carousel-content'>
+          {this.state.relatedProducts.map((productId) =>
+            <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}
+        </div>
         <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right'/>
       </div>
-      {this.state.relatedProducts.map((productId) =>
-        <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}
       {modal}
 
     </div>)

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -52,7 +52,7 @@ class RelatedProducts extends React.Component {
     }
     return (
     <div id='related-products'>
-      <h3>Related Products</h3>
+      <h3>RELATED PRODUCTS</h3>
       <Carousel products={this.state.relatedProducts} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton} sliderComp='carousel-related-products'/>
       {modal}
     </div>)

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -43,12 +43,14 @@ class RelatedProducts extends React.Component {
 
   slideLeft() {
     var scroller = document.getElementById('carousel-content');
-    scroller.scrollLeft = scroller.scrollLeft - 240;
+    scroller.scrollLeft = scroller.scrollLeft - 260;
+    console.log(scroller.scrollLeft);
   }
 
   slideRight() {
     var scroller = document.getElementById('carousel-content');
-    scroller.scrollLeft = scroller.scrollLeft + 240;
+    scroller.scrollLeft = scroller.scrollLeft + 260;
+    console.log(scroller.scrollLeft);
   }
 
   componentDidMount() {

--- a/client/src/components/relatedItems/RelatedProducts.jsx
+++ b/client/src/components/relatedItems/RelatedProducts.jsx
@@ -16,6 +16,10 @@ class RelatedProducts extends React.Component {
 
     this.getRelatedProducts = this.getRelatedProducts.bind(this);
     this.handleActionButton = this.handleActionButton.bind(this);
+    this.slideLeft = this.slideLeft.bind(this);
+    this.slideRight = this.slideRight.bind(this);
+
+
   }
 
   getRelatedProducts(productId) {
@@ -37,6 +41,16 @@ class RelatedProducts extends React.Component {
     this.setState({showModal: newState, comparisonProductId: productId});
   }
 
+  slideLeft() {
+    var scroller = document.getElementById('carousel-content');
+    scroller.scrollLeft = scroller.scrollLeft - 240;
+  }
+
+  slideRight() {
+    var scroller = document.getElementById('carousel-content');
+    scroller.scrollLeft = scroller.scrollLeft + 240;
+  }
+
   componentDidMount() {
     this.getRelatedProducts(this.props.productId);
   }
@@ -51,12 +65,12 @@ class RelatedProducts extends React.Component {
     <div id='related-products'>
       <h3>Related Products</h3>
       <div id='carousel'>
-        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left'/>
+        <FontAwesomeIcon size='2x' icon={faChevronLeft} className='carousel-button left' onClick={this.slideLeft}/>
         <div id='carousel-content'>
           {this.state.relatedProducts.map((productId) =>
             <ProductCard key={productId.toString()} productId={productId} setNewProductId={this.props.setNewProductId} actionButtonIcon={faStar} actionClick={this.handleActionButton}/>)}
         </div>
-        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right'/>
+        <FontAwesomeIcon size='2x' icon={faChevronRight} className='carousel-button right' onClick={this.slideRight}/>
       </div>
       {modal}
 


### PR DESCRIPTION
This PR introduces a Carousel component that is used for both the Related Products and Outfits components.

This update includes:

- New CSS coloring for the whole widget
- Left and right arrows that appear / disappear appropriately, including on screen resizing
- Change in component structure.  Instead of Related Products -> Product Card, it is now Related Products -> Carousel -> Product Card; Similarly, it is now Outfits -> Carousel -> Product Card

![image](https://user-images.githubusercontent.com/93614292/197453497-b0b8de73-204b-4c8c-aa5c-2a3cda49be99.png)
