### PR TITLE
Improve Cumulative Shift Layout and Dark Mode for product cards

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -237,7 +237,6 @@ td:nth-child(2) {
   display: inline-block;
   width: 240px;
   height: 300px;
-  background-color: white;
   border-radius: 10px;
   margin-left: 5px;
   margin-right: 5px;

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -68,7 +68,6 @@
  /* RELATED ITEMS AND COMPARISON FORMATTING */
 
  #related-items-and-comparisons{
-  position: relative;
   margin-top: 10px;
   padding-left: 10px;
   padding-bottom: 10px;
@@ -213,6 +212,7 @@ td:nth-child(2) {
 
 .carousel-button{
   background-color: white;
+  color: black;
   border-radius: 100%;
   position: absolute;
   opacity: 0.5;

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -75,7 +75,7 @@
  }
 
  #outfits, #related-products {
-  margin-top: 50px
+  margin-top: 25px
  }
 
  .ri-action-button {
@@ -253,6 +253,7 @@ td:nth-child(2) {
 
 .po-container {
   padding: 10px;
+  height: 1200px;
 }
 
 .po-product-info > section {


### PR DESCRIPTION
This change includes CSS file changes that:

- remove the position: relative from the related items div
- Adds a fixed height to the product overview widget
- removes the background color used for product cards so that the dark mode appropriately renders

The CLS changes showed improvements on the local machine.  Before and after images are shown here:
![image](https://user-images.githubusercontent.com/93614292/199154139-d98f3898-344b-4f16-a35f-f9e44ae9aa19.png)
